### PR TITLE
fix: scientificNotation in small negative numbers

### DIFF
--- a/src/__tests__/convert.test.ts
+++ b/src/__tests__/convert.test.ts
@@ -118,8 +118,11 @@ test("Science Notation to Decimal", () => {
   expect(starkString("4.5e-8").scientificNotationToDecimal().toString()).toBe(
     "0.000000045",
   );
-  expect(starkString("-2.9e-6").scientificNotationToDecimal().toString()).toBe(
-    "-0.0000029",
+  expect(starkString("-1.7e-12").scientificNotationToDecimal().toString()).toBe(
+    "-0.0000000000017",
+  );
+  expect(starkString(-2.9e-15).scientificNotationToDecimal().toString()).toBe(
+    "-0.0000000000000029",
   );
   expect(starkString("-8.2").scientificNotationToDecimal().toString()).toBe(
     "-8.2",

--- a/src/core/scientificNotation.ts
+++ b/src/core/scientificNotation.ts
@@ -19,8 +19,8 @@ function scientificNotationToDecimal(value: number | string): string {
     }
   }
 
-  if (sign < 0 && value > 0) {
-    value = -value;
+  if (sign < 0 && Number(value) > 0) {
+    value = `-${value}`;
   }
 
   return String(value);


### PR DESCRIPTION
There was a small bug with scientificNotationToDecimal in really small negative numbers (like -1.6e-12) which was fixed